### PR TITLE
Fix unable to build and update UI to Fluent style

### DIFF
--- a/src/DocxToSource/App.xaml
+++ b/src/DocxToSource/App.xaml
@@ -1,9 +1,14 @@
-﻿<Application x:Class="DocxToSource.App"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:DocxToSource"
-             StartupUri="MainWindow.xaml">
+﻿<Application
+    x:Class="DocxToSource.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:DocxToSource"
+    StartupUri="MainWindow.xaml">
     <Application.Resources>
-         
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Themes/Fluent.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/DocxToSource/Controls/OpenXmlPartTreeViewItem.cs
+++ b/src/DocxToSource/Controls/OpenXmlPartTreeViewItem.cs
@@ -56,9 +56,9 @@ namespace DocxToSource.Controls
         /// <exception cref="ArgumentNullException">
         /// <paramref name="p"/> is <see langword="null"/>.
         /// </exception>
-        public OpenXmlPartTreeViewItem(IdPartPair p)
-            : base(p != null && p.OpenXmlPart != null && p.OpenXmlPart.Parts != null &&
-                  (p.OpenXmlPart.Parts.Any() || p.OpenXmlPart.RootElement != null))
+        public OpenXmlPartTreeViewItem(IdPartPair? p)
+            : base(p.HasValue && p.Value.OpenXmlPart != null && p.Value.OpenXmlPart.Parts != null &&
+                  (p.Value.OpenXmlPart.Parts.Any() || p.Value.OpenXmlPart.RootElement != null))
         {
             part = p ?? throw new ArgumentNullException(nameof(p));
         }

--- a/src/DocxToSource/DocxToSource.csproj
+++ b/src/DocxToSource/DocxToSource.csproj
@@ -1,29 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>WinExe</OutputType>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
-        <UseWPF>true</UseWPF>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Authors>Ryan Boggs</Authors>
-        <Company>Ryan Boggs</Company>
-        <PackageProjectUrl>https://github.com/rmboggs/docxtosource</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/rmboggs/docxtosource</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
-        <PackageTags>openxml;DocumentFormat</PackageTags>
-        <Version>0.1.0-alpha</Version>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0-windows7.0</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Authors>Ryan Boggs</Authors>
+    <Company>Ryan Boggs</Company>
+    <PackageProjectUrl>https://github.com/rmboggs/docxtosource</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/rmboggs/docxtosource</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>openxml;DocumentFormat</PackageTags>
+    <Version>0.1.0-alpha</Version>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
-        <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
-        <PackageReference Include="Prism.Wpf" Version="9.0.537" />
-        <PackageReference Include="System.CodeDom" Version="9.0.4" />
-        <PackageReference Include="System.IO.Packaging" Version="9.0.4" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
+    <PackageReference Include="Prism.Wpf" Version="9.0.537" />
+    <PackageReference Include="System.CodeDom" Version="9.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.4" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Serialize.OpenXml.CodeGen\src\Serialize.OpenXml.CodeGen\Serialize.OpenXml.CodeGen.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Serialize.OpenXml.CodeGen\src\Serialize.OpenXml.CodeGen\Serialize.OpenXml.CodeGen.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/DocxToSource/DocxToSource.csproj
+++ b/src/DocxToSource/DocxToSource.csproj
@@ -1,29 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Authors>Ryan Boggs</Authors>
-    <Company>Ryan Boggs</Company>
-    <PackageProjectUrl>https://github.com/rmboggs/docxtosource</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/rmboggs/docxtosource</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>openxml;DocumentFormat</PackageTags>
-    <Version>0.1.0-alpha</Version>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>WinExe</OutputType>
+        <TargetFramework>net9.0-windows7.0</TargetFramework>
+        <UseWPF>true</UseWPF>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <Authors>Ryan Boggs</Authors>
+        <Company>Ryan Boggs</Company>
+        <PackageProjectUrl>https://github.com/rmboggs/docxtosource</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/rmboggs/docxtosource</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageTags>openxml;DocumentFormat</PackageTags>
+        <Version>0.1.0-alpha</Version>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AvalonEdit" Version="6.1.2.30" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.14.0" />
-    <PackageReference Include="Prism.Wpf" Version="8.1.97" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0" />
-    <PackageReference Include="System.IO.Packaging" Version="5.0.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
+        <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
+        <PackageReference Include="Prism.Wpf" Version="9.0.537" />
+        <PackageReference Include="System.CodeDom" Version="9.0.4" />
+        <PackageReference Include="System.IO.Packaging" Version="9.0.4" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Serialize.OpenXml.CodeGen\src\Serialize.OpenXml.CodeGen\Serialize.OpenXml.CodeGen.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Serialize.OpenXml.CodeGen\src\Serialize.OpenXml.CodeGen\Serialize.OpenXml.CodeGen.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/src/DocxToSource/MainWindow.xaml
+++ b/src/DocxToSource/MainWindow.xaml
@@ -7,6 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:source="http://icsharpcode.net/sharpdevelop/avalonedit"
     xmlns:tree="clr-namespace:DocxToSource.Controls"
+    x:Name="MyMainWindow"
     Title="Docx To Source"
     Width="1600"
     Height="1000"
@@ -35,12 +36,117 @@
             <Setter Property="VerticalAlignment" Value="Stretch" />
             <Setter Property="HorizontalAlignment" Value="Stretch" />
         </Style>
-        <Style BasedOn="{StaticResource {x:Type TreeViewItem}}" TargetType="TreeViewItem" />
         <Style BasedOn="{StaticResource {x:Type TreeViewItem}}" TargetType="tree:OpenXmlTreeViewItem" />
         <Style BasedOn="{StaticResource {x:Type TreeViewItem}}" TargetType="tree:OpenXmlElementTreeViewItem" />
         <Style BasedOn="{StaticResource {x:Type TreeViewItem}}" TargetType="tree:OpenXmlPartTreeViewItem" />
         <Style BasedOn="{StaticResource {x:Type TreeViewItem}}" TargetType="tree:OpenXmlPackageTreeViewItem" />
         <Style BasedOn="{StaticResource {x:Type TreeView}}" TargetType="tree:OpenXmlTreeView" />
+        <Style
+            x:Key="DropMenuCheckboxStyle"
+            BasedOn="{StaticResource {x:Type CheckBox}}"
+            TargetType="CheckBox">
+            <Setter Property="FontFamily" Value="Segoe UI" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+        <Style BasedOn="{StaticResource {x:Type source:SearchPanel}}" TargetType="source:SearchPanel">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Border
+                            Margin="0,0,10,0"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            Background="{DynamicResource WindowBackground}"
+                            BorderThickness="1"
+                            CornerRadius="7"
+                            Cursor="Arrow"
+                            UseLayoutRounding="True">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBox
+                                    Name="PART_searchTextBox"
+                                    Width="250"
+                                    Margin="3"
+                                    Focusable="True"
+                                    FontFamily="Segou UI">
+                                    <TextBox.Text>
+                                        <Binding
+                                            Path="SearchPattern"
+                                            RelativeSource="{RelativeSource TemplatedParent}"
+                                            UpdateSourceTrigger="PropertyChanged">
+                                            <Binding.ValidationRules>
+                                                <ExceptionValidationRule />
+                                            </Binding.ValidationRules>
+                                        </Binding>
+                                    </TextBox.Text>
+                                </TextBox>
+                                <source:DropDownButton
+                                    Width="18"
+                                    Height="24"
+                                    VerticalAlignment="Center"
+                                    Foreground="{x:Static SystemColors.MenuBrush}">
+                                    <source:DropDownButton.DropDownContent>
+                                        <Popup Name="PART_dropdownPopup" StaysOpen="False">
+                                            <Border
+                                                Padding="1"
+                                                Background="{DynamicResource WindowBackground}"
+                                                BorderBrush="{DynamicResource TextBoxBorderBrush}"
+                                                BorderThickness="1">
+                                                <StackPanel>
+                                                    <CheckBox
+                                                        Margin="3"
+                                                        Content="Match Case"
+                                                        IsChecked="{Binding MatchCase, RelativeSource={RelativeSource TemplatedParent}}"
+                                                        Style="{DynamicResource DropMenuCheckboxStyle}" />
+                                                    <CheckBox
+                                                        Margin="3"
+                                                        Content="Match Whole Words"
+                                                        IsChecked="{Binding WholeWords, RelativeSource={RelativeSource TemplatedParent}}"
+                                                        Style="{DynamicResource DropMenuCheckboxStyle}" />
+                                                    <CheckBox
+                                                        Margin="3"
+                                                        Content="Use Regular Expressions"
+                                                        IsChecked="{Binding UseRegex, RelativeSource={RelativeSource TemplatedParent}}"
+                                                        Style="{DynamicResource DropMenuCheckboxStyle}" />
+                                                </StackPanel>
+                                            </Border>
+                                        </Popup>
+                                    </source:DropDownButton.DropDownContent>
+                                </source:DropDownButton>
+                                <Button
+                                    Width="24"
+                                    Height="24"
+                                    Margin="1,3"
+                                    Padding="0"
+                                    VerticalAlignment="Center"
+                                    Command="source:SearchCommands.FindPrevious"
+                                    Content="&#xE76B;"
+                                    FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                <Button
+                                    Width="24"
+                                    Height="24"
+                                    Margin="1,3"
+                                    Padding="0"
+                                    VerticalAlignment="Center"
+                                    Command="source:SearchCommands.FindNext"
+                                    Content="&#xE76C;"
+                                    FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                <Button
+                                    Width="24"
+                                    Height="24"
+                                    Margin="5,0,4,0"
+                                    Padding="0"
+                                    VerticalAlignment="Center"
+                                    Command="source:SearchCommands.CloseSearchPanel"
+                                    Content="&#xE894;"
+                                    Focusable="False"
+                                    FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                            </StackPanel>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
     </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>

--- a/src/DocxToSource/MainWindow.xaml
+++ b/src/DocxToSource/MainWindow.xaml
@@ -1,37 +1,25 @@
-﻿<Window
-    x:Class="DocxToSource.MainWindow"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="clr-namespace:DocxToSource"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:source="http://icsharpcode.net/sharpdevelop/avalonedit"
-    xmlns:tree="clr-namespace:DocxToSource.Controls"
-    x:Name="MyMainWindow"
-    Title="Docx To Source"
-    Width="1600"
-    Height="1000"
-    WindowStartupLocation="CenterScreen"
-    mc:Ignorable="d">
+﻿<Window x:Class="DocxToSource.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:source="http://icsharpcode.net/sharpdevelop/avalonedit"
+        xmlns:local="clr-namespace:DocxToSource"
+        xmlns:tree="clr-namespace:DocxToSource.Controls"
+        mc:Ignorable="d"
+        x:Name="MyMainWindow"
+        Title="Docx To Source" Width="1600" Height="1000"
+        WindowStartupLocation="CenterScreen">
     <Window.DataContext>
-        <local:MainWindowModel />
+        <local:MainWindowModel/>
     </Window.DataContext>
     <Window.InputBindings>
-        <KeyBinding
-            Key="Q"
-            Command="{Binding QuitCommand}"
-            Modifiers="Ctrl" />
-        <KeyBinding
-            Key="O"
-            Command="{Binding OpenCommand}"
-            Modifiers="Ctrl" />
-        <KeyBinding
-            Key="C"
-            Command="{Binding CloseCommand}"
-            Modifiers="Ctrl" />
+        <KeyBinding Key="Q" Modifiers="Ctrl" Command="{Binding QuitCommand}"/>
+        <KeyBinding Key="O" Modifiers="Ctrl" Command="{Binding OpenCommand}"/>
+        <KeyBinding Key="C" Modifiers="Ctrl" Command="{Binding CloseCommand}"/>
     </Window.InputBindings>
     <Window.Resources>
-        <Style BasedOn="{StaticResource {x:Type GridSplitter}}" TargetType="{x:Type GridSplitter}">
+        <Style TargetType="{x:Type GridSplitter}" BasedOn="{StaticResource {x:Type GridSplitter}}">
             <Setter Property="ShowsPreview" Value="True" />
             <Setter Property="VerticalAlignment" Value="Stretch" />
             <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -41,10 +29,7 @@
         <Style BasedOn="{StaticResource {x:Type TreeViewItem}}" TargetType="tree:OpenXmlPartTreeViewItem" />
         <Style BasedOn="{StaticResource {x:Type TreeViewItem}}" TargetType="tree:OpenXmlPackageTreeViewItem" />
         <Style BasedOn="{StaticResource {x:Type TreeView}}" TargetType="tree:OpenXmlTreeView" />
-        <Style
-            x:Key="DropMenuCheckboxStyle"
-            BasedOn="{StaticResource {x:Type CheckBox}}"
-            TargetType="CheckBox">
+        <Style x:Key="DropMenuCheckboxStyle" BasedOn="{StaticResource {x:Type CheckBox}}" TargetType="CheckBox">
             <Setter Property="FontFamily" Value="Segoe UI" />
             <Setter Property="FontSize" Value="12" />
             <Setter Property="VerticalAlignment" Value="Center" />
@@ -53,94 +38,33 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate>
-                        <Border
-                            Margin="0,0,10,0"
-                            HorizontalAlignment="Right"
-                            VerticalAlignment="Top"
-                            Background="{DynamicResource WindowBackground}"
-                            BorderThickness="1"
-                            CornerRadius="7"
-                            Cursor="Arrow"
-                            UseLayoutRounding="True">
+                        <Border Margin="0,0,10,0" HorizontalAlignment="Right" VerticalAlignment="Top" Background="{DynamicResource WindowBackground}" BorderThickness="1" CornerRadius="7" Cursor="Arrow" UseLayoutRounding="True">
                             <StackPanel Orientation="Horizontal">
-                                <TextBox
-                                    Name="PART_searchTextBox"
-                                    Width="250"
-                                    Margin="3"
-                                    Focusable="True"
-                                    FontFamily="Segou UI">
+                                <TextBox Name="PART_searchTextBox" Width="250" Margin="3" Focusable="True" FontFamily="Segou UI">
                                     <TextBox.Text>
-                                        <Binding
-                                            Path="SearchPattern"
-                                            RelativeSource="{RelativeSource TemplatedParent}"
-                                            UpdateSourceTrigger="PropertyChanged">
+                                        <Binding Path="SearchPattern" RelativeSource="{RelativeSource TemplatedParent}" UpdateSourceTrigger="PropertyChanged">
                                             <Binding.ValidationRules>
                                                 <ExceptionValidationRule />
                                             </Binding.ValidationRules>
                                         </Binding>
                                     </TextBox.Text>
                                 </TextBox>
-                                <source:DropDownButton
-                                    Width="18"
-                                    Height="24"
-                                    VerticalAlignment="Center"
-                                    Foreground="{x:Static SystemColors.MenuBrush}">
+                                <source:DropDownButton Width="18" Height="24" VerticalAlignment="Center" Foreground="{x:Static SystemColors.MenuBrush}">
                                     <source:DropDownButton.DropDownContent>
                                         <Popup Name="PART_dropdownPopup" StaysOpen="False">
-                                            <Border
-                                                Padding="1"
-                                                Background="{DynamicResource WindowBackground}"
-                                                BorderBrush="{DynamicResource TextBoxBorderBrush}"
-                                                BorderThickness="1">
+                                            <Border Padding="1" Background="{DynamicResource WindowBackground}" BorderBrush="{DynamicResource TextBoxBorderBrush}" BorderThickness="1">
                                                 <StackPanel>
-                                                    <CheckBox
-                                                        Margin="3"
-                                                        Content="Match Case"
-                                                        IsChecked="{Binding MatchCase, RelativeSource={RelativeSource TemplatedParent}}"
-                                                        Style="{DynamicResource DropMenuCheckboxStyle}" />
-                                                    <CheckBox
-                                                        Margin="3"
-                                                        Content="Match Whole Words"
-                                                        IsChecked="{Binding WholeWords, RelativeSource={RelativeSource TemplatedParent}}"
-                                                        Style="{DynamicResource DropMenuCheckboxStyle}" />
-                                                    <CheckBox
-                                                        Margin="3"
-                                                        Content="Use Regular Expressions"
-                                                        IsChecked="{Binding UseRegex, RelativeSource={RelativeSource TemplatedParent}}"
-                                                        Style="{DynamicResource DropMenuCheckboxStyle}" />
+                                                    <CheckBox Margin="3" Content="Match Case" IsChecked="{Binding MatchCase, RelativeSource={RelativeSource TemplatedParent}}" Style="{DynamicResource DropMenuCheckboxStyle}" />
+                                                    <CheckBox Margin="3" Content="Match Whole Words" IsChecked="{Binding WholeWords, RelativeSource={RelativeSource TemplatedParent}}" Style="{DynamicResource DropMenuCheckboxStyle}" />
+                                                    <CheckBox Margin="3" Content="Use Regular Expressions" IsChecked="{Binding UseRegex, RelativeSource={RelativeSource TemplatedParent}}" Style="{DynamicResource DropMenuCheckboxStyle}" />
                                                 </StackPanel>
                                             </Border>
                                         </Popup>
                                     </source:DropDownButton.DropDownContent>
                                 </source:DropDownButton>
-                                <Button
-                                    Width="24"
-                                    Height="24"
-                                    Margin="1,3"
-                                    Padding="0"
-                                    VerticalAlignment="Center"
-                                    Command="source:SearchCommands.FindPrevious"
-                                    Content="&#xE76B;"
-                                    FontFamily="{StaticResource SymbolThemeFontFamily}" />
-                                <Button
-                                    Width="24"
-                                    Height="24"
-                                    Margin="1,3"
-                                    Padding="0"
-                                    VerticalAlignment="Center"
-                                    Command="source:SearchCommands.FindNext"
-                                    Content="&#xE76C;"
-                                    FontFamily="{StaticResource SymbolThemeFontFamily}" />
-                                <Button
-                                    Width="24"
-                                    Height="24"
-                                    Margin="5,0,4,0"
-                                    Padding="0"
-                                    VerticalAlignment="Center"
-                                    Command="source:SearchCommands.CloseSearchPanel"
-                                    Content="&#xE894;"
-                                    Focusable="False"
-                                    FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                <Button Width="24" Height="24" Margin="1,3" Padding="0" VerticalAlignment="Center" Command="source:SearchCommands.FindPrevious" Content="&#xE76B;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                <Button Width="24" Height="24" Margin="1,3" Padding="0" VerticalAlignment="Center" Command="source:SearchCommands.FindNext" Content="&#xE76C;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                <Button Width="24" Height="24" Margin="5,0,4,0" Padding="0" VerticalAlignment="Center" Command="source:SearchCommands.CloseSearchPanel" Content="&#xE894;" Focusable="False" FontFamily="{StaticResource SymbolThemeFontFamily}" />
                             </StackPanel>
                         </Border>
                     </ControlTemplate>
@@ -159,59 +83,32 @@
         </Grid.ColumnDefinitions>
         <Menu Height="Auto">
             <MenuItem Header="_File">
-                <MenuItem
-                    Command="{Binding OpenCommand}"
-                    Header="_Open"
-                    InputGestureText="Ctrl+O" />
-                <MenuItem
-                    Command="{Binding CloseCommand}"
-                    Header="_Close"
-                    InputGestureText="Ctrl+C" />
-                <Separator />
-                <MenuItem
-                    Command="{Binding QuitCommand}"
-                    Header="_Quit"
-                    InputGestureText="Ctrl+Q" />
+                <MenuItem Header="_Open" InputGestureText="Ctrl+O" Command="{Binding OpenCommand}"/>
+                <MenuItem Header="_Close" InputGestureText="Ctrl+C" Command="{Binding CloseCommand}"/>
+                <Separator/>
+                <MenuItem Header="_Quit" InputGestureText="Ctrl+Q" Command="{Binding QuitCommand}"/>
             </MenuItem>
             <MenuItem Header="_Source Code">
-                <MenuItem
-                    Header="_Generate Source Code"
-                    IsCheckable="True"
-                    IsChecked="{Binding GenerateSourceCode}" />
-                <Separator />
-                <MenuItem
-                    Header="_Word Wrap"
-                    IsCheckable="True"
-                    IsChecked="{Binding WordWrap}" />
-                <MenuItem
-                    Header="Syntax _Highlighting"
-                    IsCheckable="True"
-                    IsChecked="{Binding HighlightSyntax}" />
+                <MenuItem Header="_Generate Source Code" IsCheckable="True" IsChecked="{Binding GenerateSourceCode}"/>
+                <Separator/>
+                <MenuItem Header="_Word Wrap" IsCheckable="True" IsChecked="{Binding WordWrap}"/>
+                <MenuItem Header="Syntax _Highlighting" IsCheckable="True" IsChecked="{Binding HighlightSyntax}" />
             </MenuItem>
         </Menu>
-        <ComboBox
-            Grid.Column="1"
-            Width="150"
-            Margin="0,0,10,0"
-            HorizontalAlignment="Right"
-            ItemsSource="{Binding LanguageDefinitions}"
-            SelectedItem="{Binding SelectedLanguage}" />
+        <ComboBox Grid.Column="1" Width="150" Margin="0,0,10,0" HorizontalAlignment="Right" ItemsSource="{Binding LanguageDefinitions}" SelectedItem="{Binding SelectedLanguage}" />
         <Grid Grid.Row="1" Grid.ColumnSpan="2">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="5" />
-                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="5"/>
+                <ColumnDefinition Width="2*"/>
             </Grid.ColumnDefinitions>
             <tree:OpenXmlTreeView
                 Grid.Column="0"
-                d:ItemsSource="{d:SampleData ItemCount=5}"
                 BorderThickness="0"
+                d:ItemsSource="{d:SampleData ItemCount=5}"
                 ItemsSource="{Binding Path=TreeData}"
-                SelectedTreeItem="{Binding Path=SelectedItem, Mode=TwoWay}" />
-            <GridSplitter
-                Grid.Column="1"
-                Width="5"
-                ResizeDirection="Columns" />
+                SelectedTreeItem="{Binding Path=SelectedItem, Mode=TwoWay}"/>
+            <GridSplitter ResizeDirection="Columns" Width="5" Grid.Column="1" />
             <Grid Grid.Column="2">
                 <Grid.RowDefinitions>
                     <RowDefinition>
@@ -219,10 +116,10 @@
                             <Style TargetType="RowDefinition">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsOpenXmlElement}" Value="True">
-                                        <Setter Property="Height" Value="*" />
+                                        <Setter Property="Height" Value="*"/>
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding IsOpenXmlElement}" Value="False">
-                                        <Setter Property="Height" Value="0" />
+                                        <Setter Property="Height" Value="0"/>
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
@@ -233,43 +130,30 @@
                             <Style TargetType="{x:Type RowDefinition}">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsOpenXmlElement}" Value="True">
-                                        <Setter Property="Height" Value="5" />
+                                        <Setter Property="Height" Value="5"/>
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding IsOpenXmlElement}" Value="False">
-                                        <Setter Property="Height" Value="0" />
+                                        <Setter Property="Height" Value="0"/>
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </RowDefinition.Style>
                     </RowDefinition>
-                    <RowDefinition />
+                    <RowDefinition/>
                 </Grid.RowDefinitions>
                 <Grid.Resources>
                     <Style BasedOn="{StaticResource {x:Type source:TextEditor}}" TargetType="{x:Type source:TextEditor}">
-                        <Setter Property="FontFamily" Value="Consolas" />
-                        <Setter Property="FontSize" Value="12" />
-                        <Setter Property="ShowLineNumbers" Value="True" />
-                        <Setter Property="WordWrap" Value="{Binding WordWrap}" />
-                        <Setter Property="BorderThickness" Value="0" />
-                        <Setter Property="IsReadOnly" Value="True" />
+                        <Setter Property="FontFamily" Value="Consolas"/>
+                        <Setter Property="FontSize" Value="12"/>
+                        <Setter Property="ShowLineNumbers" Value="True"/>
+                        <Setter Property="WordWrap" Value="{Binding WordWrap}"/>
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="IsReadOnly" Value="True"/>
                     </Style>
                 </Grid.Resources>
-                <source:TextEditor
-                    x:Name="xXmlSourceEditor"
-                    Grid.Row="0"
-                    Background="WhiteSmoke"
-                    Document="{Binding XmlSourceDocument}"
-                    SyntaxHighlighting="{Binding XmlSourceDocumentSyntax}" />
-                <GridSplitter
-                    Grid.Row="1"
-                    Height="5"
-                    ResizeDirection="Rows" />
-                <source:TextEditor
-                    x:Name="xCodeSourceEditor"
-                    Grid.Row="2"
-                    Background="FloralWhite"
-                    Document="{Binding CodeDocument}"
-                    SyntaxHighlighting="{Binding CodeDocumentSyntax}" />
+                <source:TextEditor x:Name="xXmlSourceEditor" Grid.Row="0" Background="WhiteSmoke" Document ="{Binding XmlSourceDocument}" SyntaxHighlighting="{Binding XmlSourceDocumentSyntax}"/>
+                <GridSplitter ResizeDirection="Rows" Height="5" Grid.Row="1"/>
+                <source:TextEditor x:Name="xCodeSourceEditor" Grid.Row="2" Background="FloralWhite" Document="{Binding CodeDocument}" SyntaxHighlighting="{Binding CodeDocumentSyntax}"/>
             </Grid>
         </Grid>
     </Grid>

--- a/src/DocxToSource/MainWindow.xaml
+++ b/src/DocxToSource/MainWindow.xaml
@@ -1,79 +1,122 @@
-﻿<Window x:Class="DocxToSource.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:source="http://icsharpcode.net/sharpdevelop/avalonedit"
-        xmlns:local="clr-namespace:DocxToSource"
-        xmlns:tree="clr-namespace:DocxToSource.Controls"
-        mc:Ignorable="d"
-        Title="Docx To Source" Height="600" Width="800"
-        WindowStartupLocation="CenterScreen">
+﻿<Window
+    x:Class="DocxToSource.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:DocxToSource"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:source="http://icsharpcode.net/sharpdevelop/avalonedit"
+    xmlns:tree="clr-namespace:DocxToSource.Controls"
+    Title="Docx To Source"
+    Width="1600"
+    Height="1000"
+    WindowStartupLocation="CenterScreen"
+    mc:Ignorable="d">
     <Window.DataContext>
-        <local:MainWindowModel/>
+        <local:MainWindowModel />
     </Window.DataContext>
     <Window.InputBindings>
-        <KeyBinding Key="Q" Modifiers="Ctrl" Command="{Binding QuitCommand}"/>
-        <KeyBinding Key="O" Modifiers="Ctrl" Command="{Binding OpenCommand}"/>
-        <KeyBinding Key="C" Modifiers="Ctrl" Command="{Binding CloseCommand}"/>
+        <KeyBinding
+            Key="Q"
+            Command="{Binding QuitCommand}"
+            Modifiers="Ctrl" />
+        <KeyBinding
+            Key="O"
+            Command="{Binding OpenCommand}"
+            Modifiers="Ctrl" />
+        <KeyBinding
+            Key="C"
+            Command="{Binding CloseCommand}"
+            Modifiers="Ctrl" />
     </Window.InputBindings>
     <Window.Resources>
-        <Style TargetType="{x:Type GridSplitter}">
-            <Setter Property="ShowsPreview" Value="True"/>
-            <Setter Property="VerticalAlignment" Value="Stretch"/>
-            <Setter Property="HorizontalAlignment" Value="Stretch"/>
+        <Style BasedOn="{StaticResource {x:Type GridSplitter}}" TargetType="{x:Type GridSplitter}">
+            <Setter Property="ShowsPreview" Value="True" />
+            <Setter Property="VerticalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
         </Style>
+        <Style BasedOn="{StaticResource {x:Type TreeViewItem}}" TargetType="TreeViewItem" />
+        <Style BasedOn="{StaticResource {x:Type TreeViewItem}}" TargetType="tree:OpenXmlTreeViewItem" />
+        <Style BasedOn="{StaticResource {x:Type TreeViewItem}}" TargetType="tree:OpenXmlElementTreeViewItem" />
+        <Style BasedOn="{StaticResource {x:Type TreeViewItem}}" TargetType="tree:OpenXmlPartTreeViewItem" />
+        <Style BasedOn="{StaticResource {x:Type TreeViewItem}}" TargetType="tree:OpenXmlPackageTreeViewItem" />
+        <Style BasedOn="{StaticResource {x:Type TreeView}}" TargetType="tree:OpenXmlTreeView" />
     </Window.Resources>
-    <DockPanel LastChildFill="True">
-
-        <Menu DockPanel.Dock="Top" Height="auto">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Menu Height="Auto">
             <MenuItem Header="_File">
-                <MenuItem Header="_Open" InputGestureText="Ctrl+O" Command="{Binding OpenCommand}"/>
-                <MenuItem Header="_Close" InputGestureText="Ctrl+C" Command="{Binding CloseCommand}"/>
-                <Separator/>
-                <MenuItem Header="_Quit" InputGestureText="Ctrl+Q" Command="{Binding QuitCommand}"/>
+                <MenuItem
+                    Command="{Binding OpenCommand}"
+                    Header="_Open"
+                    InputGestureText="Ctrl+O" />
+                <MenuItem
+                    Command="{Binding CloseCommand}"
+                    Header="_Close"
+                    InputGestureText="Ctrl+C" />
+                <Separator />
+                <MenuItem
+                    Command="{Binding QuitCommand}"
+                    Header="_Quit"
+                    InputGestureText="Ctrl+Q" />
             </MenuItem>
             <MenuItem Header="_Source Code">
-                <MenuItem Header="_Generate Source Code" IsCheckable="True" IsChecked="{Binding GenerateSourceCode}"/>
-                <Separator/>
-                <MenuItem Header="_Word Wrap" IsCheckable="True" IsChecked="{Binding WordWrap}"/>
-                <MenuItem Header="Syntax _Highlighting" IsCheckable="True" IsChecked="{Binding HighlightSyntax}" />
+                <MenuItem
+                    Header="_Generate Source Code"
+                    IsCheckable="True"
+                    IsChecked="{Binding GenerateSourceCode}" />
+                <Separator />
+                <MenuItem
+                    Header="_Word Wrap"
+                    IsCheckable="True"
+                    IsChecked="{Binding WordWrap}" />
+                <MenuItem
+                    Header="Syntax _Highlighting"
+                    IsCheckable="True"
+                    IsChecked="{Binding HighlightSyntax}" />
             </MenuItem>
         </Menu>
-        <ToolBar DockPanel.Dock="Top" Background="#FFF0F0F0" VerticalContentAlignment="Center">
-            <TextBlock Margin="5 0">Language:</TextBlock>
-            <ComboBox
-                Width="125"
-                ItemsSource="{Binding LanguageDefinitions}"
-                SelectedItem="{Binding SelectedLanguage}">
-            </ComboBox>
-        </ToolBar>
-        <StatusBar DockPanel.Dock="Bottom">
-            <TextBlock/>
-        </StatusBar>
-        <Grid>
+        <ComboBox
+            Grid.Column="1"
+            Width="150"
+            Margin="0,0,10,0"
+            HorizontalAlignment="Right"
+            ItemsSource="{Binding LanguageDefinitions}"
+            SelectedItem="{Binding SelectedLanguage}" />
+        <Grid Grid.Row="1" Grid.ColumnSpan="2">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="5"/>
-                <ColumnDefinition Width="2*"/>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="5" />
+                <ColumnDefinition Width="2*" />
             </Grid.ColumnDefinitions>
             <tree:OpenXmlTreeView
                 Grid.Column="0"
+                d:ItemsSource="{d:SampleData ItemCount=5}"
                 BorderThickness="0"
                 ItemsSource="{Binding Path=TreeData}"
                 SelectedTreeItem="{Binding Path=SelectedItem, Mode=TwoWay}" />
-            <GridSplitter ResizeDirection="Columns" Width="5" Grid.Column="1"/>
+            <GridSplitter
+                Grid.Column="1"
+                Width="5"
+                ResizeDirection="Columns" />
             <Grid Grid.Column="2">
                 <Grid.RowDefinitions>
                     <RowDefinition>
                         <RowDefinition.Style>
-                            <Style TargetType="{x:Type RowDefinition}">
+                            <Style TargetType="RowDefinition">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsOpenXmlElement}" Value="True">
-                                        <Setter Property="Height" Value="*"/>
+                                        <Setter Property="Height" Value="*" />
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding IsOpenXmlElement}" Value="False">
-                                        <Setter Property="Height" Value="0"/>
+                                        <Setter Property="Height" Value="0" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
@@ -84,32 +127,44 @@
                             <Style TargetType="{x:Type RowDefinition}">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsOpenXmlElement}" Value="True">
-                                        <Setter Property="Height" Value="5"/>
+                                        <Setter Property="Height" Value="5" />
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding IsOpenXmlElement}" Value="False">
-                                        <Setter Property="Height" Value="0"/>
+                                        <Setter Property="Height" Value="0" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </RowDefinition.Style>
                     </RowDefinition>
-                    <RowDefinition/>
+                    <RowDefinition />
                 </Grid.RowDefinitions>
                 <Grid.Resources>
-                    <Style TargetType="{x:Type source:TextEditor}">
-                        <Setter Property="FontFamily" Value="Consolas"/>
-                        <Setter Property="FontSize" Value="12"/>
-                        <Setter Property="ShowLineNumbers" Value="True"/>
-                        <Setter Property="WordWrap" Value="{Binding WordWrap}"/>
-                        <Setter Property="BorderThickness" Value="0"/>
-                        <Setter Property="IsReadOnly" Value="True"/>
+                    <Style BasedOn="{StaticResource {x:Type source:TextEditor}}" TargetType="{x:Type source:TextEditor}">
+                        <Setter Property="FontFamily" Value="Consolas" />
+                        <Setter Property="FontSize" Value="12" />
+                        <Setter Property="ShowLineNumbers" Value="True" />
+                        <Setter Property="WordWrap" Value="{Binding WordWrap}" />
+                        <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="IsReadOnly" Value="True" />
                     </Style>
                 </Grid.Resources>
-                <source:TextEditor x:Name="xXmlSourceEditor" Grid.Row="0" Background="WhiteSmoke" Document ="{Binding XmlSourceDocument}" SyntaxHighlighting="{Binding XmlSourceDocumentSyntax}"/>
-                <GridSplitter ResizeDirection="Rows" Height="5" Grid.Row="1"/>
-                <source:TextEditor x:Name="xCodeSourceEditor" Grid.Row="2" Background="FloralWhite" Document="{Binding CodeDocument}" SyntaxHighlighting="{Binding CodeDocumentSyntax}"/>
+                <source:TextEditor
+                    x:Name="xXmlSourceEditor"
+                    Grid.Row="0"
+                    Background="WhiteSmoke"
+                    Document="{Binding XmlSourceDocument}"
+                    SyntaxHighlighting="{Binding XmlSourceDocumentSyntax}" />
+                <GridSplitter
+                    Grid.Row="1"
+                    Height="5"
+                    ResizeDirection="Rows" />
+                <source:TextEditor
+                    x:Name="xCodeSourceEditor"
+                    Grid.Row="2"
+                    Background="FloralWhite"
+                    Document="{Binding CodeDocument}"
+                    SyntaxHighlighting="{Binding CodeDocumentSyntax}" />
             </Grid>
         </Grid>
-    </DockPanel>
-
+    </Grid>
 </Window>

--- a/src/DocxToSource/MainWindowModel.cs
+++ b/src/DocxToSource/MainWindowModel.cs
@@ -88,7 +88,7 @@ namespace DocxToSource
         /// Indicates whether or not to enable syntax highlighting in the source code
         /// windows.
         /// </summary>
-        private bool _highlightSyntax;
+        private bool _highlightSyntax = true;
 
         /// <summary>
         /// Indicates whether or not the selected item represents an

--- a/src/DocxToSource/MainWindowModel.cs
+++ b/src/DocxToSource/MainWindowModel.cs
@@ -79,7 +79,7 @@ namespace DocxToSource
         private string _fileName;
 
         /// <summary>
-        /// Indicates whether or not to automatically generate source code when 
+        /// Indicates whether or not to automatically generate source code when
         /// selecting DOM nodes.
         /// </summary>
         private bool _generateSourceCode;
@@ -102,7 +102,7 @@ namespace DocxToSource
         private OpenXmlPackage _oPkg;
 
         /// <summary>
-        /// Holds the raw package used to stage the stream information for 
+        /// Holds the raw package used to stage the stream information for
         /// validation purposes.
         /// </summary>
         private Package _pkg;
@@ -245,7 +245,7 @@ namespace DocxToSource
         }
 
         /// <summary>
-        /// Indicates whether or not to automatically generate source code when 
+        /// Indicates whether or not to automatically generate source code when
         /// selecting DOM nodes.
         /// </summary>
         public bool GenerateSourceCode
@@ -421,7 +421,6 @@ namespace DocxToSource
         {
             if (_oPkg != null)
             {
-                _oPkg.Close();
                 _oPkg.Dispose();
                 _oPkg = null;
             }


### PR DESCRIPTION
Fixes #14 
- Update dependencies
- Target ~~NET9~~ NET10
- Additional corrections necessary for changes in the latest dependencies

Additionally, this updates the UI to the modern fluent style added in NET9.

Dark:
![image](https://github.com/user-attachments/assets/3ecc1b36-da7f-494d-82bb-ea90aceef4a8)
Light:
![image](https://github.com/user-attachments/assets/3ac9bf68-e711-4992-9562-461027f19d06)